### PR TITLE
Fix response processing when using middlewares

### DIFF
--- a/flask_http_middleware/manager.py
+++ b/flask_http_middleware/manager.py
@@ -30,15 +30,17 @@ class MiddlewareManager():
 
     def process_request_and_get_response(self, request: Request) -> Response:
         if g.middleware_stack:
+            mw = None
             try:
                 mw = g.middleware_stack.pop()
                 return mw._dispatch_with_handler(request, self.process_request_and_get_response)
             except Exception as e:
                 return self.process_request_and_handle_exception(e)
             finally:
-                g.middleware_stack.append(mw)
+                if mw is not None:
+                    g.middleware_stack.append(mw)
         rv = self.dispatch_request(request)
-        return self.app.make_response(rv)
+        return self.app.finalize_request(rv)
 
     def process_request_and_handle_exception(self, error) -> Response:
         rv = self.app.handle_user_exception(error)


### PR DESCRIPTION
So far, this request should deal with 2 things:
- Setting data in 'session' global proxy;
- Make middlewares compatible with CORS extension.

Background on the issue: my application uses SSO and sets `user_id` session paratemeter. After adding `flask-http-middleware` we stopped getting `user_id` set when SSO flow is authenticating user and found out that response was processed differently in different parts of the code.