### PR TITLE
Change 3.0 to 3. so that flask versions higher than 3.0 also work

### DIFF
--- a/flask_http_middleware/manager.py
+++ b/flask_http_middleware/manager.py
@@ -47,7 +47,7 @@ class MiddlewareManager():
         return self.app.make_response(rv)
 
     def __call__(self, environ, start_response):
-        if flask_version.startswith("3.0"):
+        if flask_version.startswith("3."):
             return self.__dispatch_python_2_3_x(environ, start_response)
         elif flask_version.startswith("2.3"):
             return self.__dispatch_python_2_3_x(environ, start_response)


### PR DESCRIPTION
Dear Maintainer,

In the following piece of code in manager.py:
```python
    def __call__(self, environ, start_response):
        if flask_version.startswith("3.0"):
            return self.__dispatch_python_2_3_x(environ, start_response)
        elif flask_version.startswith("2.3"):
            return self.__dispatch_python_2_3_x(environ, start_response)
        elif flask_version.startswith("2.2"):
            return self.__dispatch_python_2_2_x(environ, start_response)
        return self.__dispatch_python_2_0_x(environ, start_response)
```
You look for the Flask version 3.0. This causes versions higher than 3.0 to fail. 
So for example if I'm using flask 3.1.0, it will try to call self.__dispatch_python_2_0_x, which fails due to a deprecation of the function:
```python
.try_trigger_before_first_request_functions()
```

I created this pull request by changing 3.0 to 3., so that versions higher than 3. will also try to call 2_3_x instead.

This fixes the issue with version 3.1.

If newer versions have other deprecations I suppose this might need a re-work.

Please accept this pull request for now so you can fix it for the newest version of Flask.